### PR TITLE
WIP: Symlink OpenBLAS so NumPy links against it

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,22 +1,32 @@
 #!/bin/bash
 
-cat > site.cfg <<EOF
-[DEFAULT]
-library_dirs = $PREFIX/lib
-include_dirs = $PREFIX/include
 
-[atlas]
-atlas_libs = openblas
-libraries = openblas
+# Depending on our platform, shared libraries end with either .so or .dylib
+if [[ `uname` == 'Darwin' ]]
+then
+    DYLIB_EXT=dylib
+else
+    DYLIB_EXT=so
+fi
 
-[openblas]
-libraries = openblas
-library_dirs = $PREFIX/lib
-include_dirs = $PREFIX/include
-
-EOF
-
+# If OpenBLAS is being used, we should be able to find the libraries.
+# As OpenBLAS now will have all symbols that BLAS or LAPACK have,
+# create libraries with the standard names that are linked back to
+# OpenBLAS. This will make it easy for NumPy to find it.
+test -f "${PREFIX}/lib/libopenblas.a" && ln -fs "${PREFIX}/lib/libopenblas.a" "${PREFIX}/lib/libblas.a"
+test -f "${PREFIX}/lib/libopenblas.a" && ln -fs "${PREFIX}/lib/libopenblas.a" "${PREFIX}/lib/liblapack.a"
+test -f "${PREFIX}/lib/libopenblas.${DYLIB_EXT}" && ln -fs "${PREFIX}/lib/libopenblas.${DYLIB_EXT}" "${PREFIX}/lib/libblas.${DYLIB_EXT}"
+test -f "${PREFIX}/lib/libopenblas.${DYLIB_EXT}" && ln -fs "${PREFIX}/lib/libopenblas.${DYLIB_EXT}" "${PREFIX}/lib/liblapack.${DYLIB_EXT}"
 
 $PYTHON setup.py config
 $PYTHON setup.py build
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+
+# Need to clean these up as we don't want them as part of the NumPy package.
+# If these are part of a BLAS (e.g. ATLAS), this won't cause us any problems
+# as those would have been existing packages and `conda-build` would have
+# ignored packaging those files anyways.
+rm -f "${PREFIX}/lib/libblas.a"
+rm -f "${PREFIX}/lib/liblapack.a"
+rm -f "${PREFIX}/lib/libblas.${DYLIB_EXT}"
+rm -f "${PREFIX}/lib/liblapack.${DYLIB_EXT}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   md5: bc56fb9fc2895aa4961802ffbdb31d0b
 
 build:
-  number: 100
+  number: 101
   # We lack openblas on Windows, and therefore can't build numpy there either currently.
   skip: true  # [win]
   features:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -14,4 +14,7 @@ import numpy.fft.fftpack_lite
 import numpy.linalg.lapack_lite
 import numpy.random.mtrand
 
+assert numpy.__config__.get_info("openblas") != {}
+numpy.__config__.show()
+
 numpy.test()


### PR DESCRIPTION
Personally, I have never had much luck with these NumPy configuration files. However, one thing that has never failed me is simply symlinking `libopenblas.so` and similar to `libblas.so` and `liblapack.so`. and similar. These are the library names that NumPy looks for anyways. So, it is able to find them. The compilers and linkers are smart enough to trace these back to the actual libraries. In the end, this works great.
- [x] Needs a build number bump.
- [x] Also, need to delete the links afterwards.
- [ ] Tweak so it can handle `noblas` or other BLAS cases.
