### PR TITLE
Add NumPy 1.10.4

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,5 +13,5 @@ echo library_dirs = %LIBRARY_LIB%
 echo include_dirs = %LIBRARY_INC%
 ) > site.cfg
 
-python setup.py build install --single-version-externally-managed --record=record.txt
+python setup.py build install
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Letting NumPy set these for us.
+# This may not be the best long term strategy,
+# but it works fine to get our first build.
+unset LDFLAGS
+
 cat > site.cfg <<EOF
 [DEFAULT]
 library_dirs = $PREFIX/lib
@@ -19,4 +24,4 @@ EOF
 
 $PYTHON setup.py config
 $PYTHON setup.py build
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt
+$PYTHON setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,15 @@ source:
   fn: numpy-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/n/numpy/numpy-{{ version }}.tar.gz
   md5: aed294de0aa1ac7bd3f9745f4f1968ad
+  patches:
+    # Adds a patch to workaround a known test failure on Linux.
+    # This patch comes from an accepted PR, but it is unclear
+    # if it will be put into a 1.10.x release. It is already
+    # in use in 1.11.x. Link below for reference.
+    #
+    # https://github.com/numpy/numpy/pull/6975
+    #
+    - numpy_PR_6975.diff
 
 build:
   number: 200

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="1.11.0" %}
+{% set version="1.10.4" %}
 
 {% set variant = 'openblas' %}
 
@@ -9,7 +9,7 @@ package:
 source:
   fn: numpy-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/n/numpy/numpy-{{ version }}.tar.gz
-  md5: bc56fb9fc2895aa4961802ffbdb31d0b
+  md5: aed294de0aa1ac7bd3f9745f4f1968ad
 
 build:
   number: 200
@@ -22,7 +22,6 @@ requirements:
   build:
     - cython
     - python
-    - setuptools
     - blas 1.1 {{ variant }}
     - openblas 0.2.18*
   run:

--- a/recipe/numpy_PR_6975.diff
+++ b/recipe/numpy_PR_6975.diff
@@ -1,0 +1,17 @@
+diff --git numpy/core/src/private/npy_config.h numpy/core/src/private/npy_config.h
+index fa20eb4..eb9c1e1 100644
+--- numpy/core/src/private/npy_config.h
++++ numpy/core/src/private/npy_config.h
+@@ -93,6 +93,12 @@
+ #undef HAVE_CATANH
+ #undef HAVE_CATANHF
+ #undef HAVE_CATANHL
++#undef HAVE_CACOS
++#undef HAVE_CACOSF
++#undef HAVE_CACOSL
++#undef HAVE_CACOSH
++#undef HAVE_CACOSHF
++#undef HAVE_CACOSHL
+ #endif
+ #undef TRIG_OK
+ 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/numpy-feedstock/issues/4

Adds NumPy 1.10.4. Going to hold on getting this merged right yet as there is some cleanup that needs to be done first. Just want to get this one out there.