### PR TITLE
Pin OpenBLAS to 0.2.18

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,5 +13,5 @@ echo library_dirs = %LIBRARY_LIB%
 echo include_dirs = %LIBRARY_INC%
 ) > site.cfg
 
-python setup.py build -j %CPU_COUNT% install --single-version-externally-managed --record=record.txt
+python setup.py build install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
     - python
     - setuptools
     - blas 1.1 {{ variant }}
-    - openblas 0.2*
+    - openblas 0.2.18*
   run:
     - python
     - blas 1.1 {{ variant }}
-    - openblas 0.2*
+    - openblas 0.2.18*
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   md5: bc56fb9fc2895aa4961802ffbdb31d0b
 
 build:
-  number: 100
+  number: 200
   # We lack openblas on Windows, and therefore can't build numpy there either currently.
   skip: true  # [win]
   features:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/numpy-feedstock/issues/1

Pins OpenBLAS to 0.2.18 as that is how the filename is versioned.

Also, switch to the 200 build number range. 101 up to 200 will be reserved for `noblas`. Basically, build number is playing a big role in how this gets installed if nothing is pinned so we need to do this to keep OpenBLAS as the default. In the future (next NumPy release which should be soon), we can make `noblas` start at 100.