### PR TITLE
Set exit code based on test result

### DIFF
--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -14,4 +14,4 @@ import numpy.fft.fftpack_lite
 import numpy.linalg.lapack_lite
 import numpy.random.mtrand
 
-numpy.test()
+sys.exit(not numpy.test().wasSuccessful())


### PR DESCRIPTION
While the tests were running previously, the build would not be failed when the tests failed. This updates our test running step so the build will fail when the tests fail. This was tested while making this PR ( https://github.com/conda-forge/numpy-feedstock/pull/5 ) for 1.10.x support.