### PR TITLE
Update Backport 6975 Patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,18 @@ source:
   md5: aed294de0aa1ac7bd3f9745f4f1968ad
   patches:
     # Adds a patch to workaround a known test failure on Linux.
-    # This patch comes from an accepted PR, but it is unclear
-    # if it will be put into a 1.10.x release. It is already
-    # in use in 1.11.x. Link below for reference.
+    # This patch comes from an accepted PR to the 1.10.x maintenance
+    # branch. However, it is unclear whether there will be a 1.10.5
+    # release. If there is, this can be dropped.
+    # 
+    # Link below for reference.
     #
-    # https://github.com/numpy/numpy/pull/6975
+    # https://github.com/numpy/numpy/pull/7657
     #
-    - numpy_PR_6975.diff
+    - numpy_PR_7657.diff
 
 build:
-  number: 200
+  number: 201
   # We lack openblas on Windows, and therefore can't build numpy there either currently.
   skip: true  # [win]
   features:

--- a/recipe/numpy_PR_7657.diff
+++ b/recipe/numpy_PR_7657.diff
@@ -1,7 +1,16 @@
 diff --git numpy/core/src/private/npy_config.h numpy/core/src/private/npy_config.h
-index fa20eb4..eb9c1e1 100644
+index fa20eb4..cd78b7d 100644
 --- numpy/core/src/private/npy_config.h
 +++ numpy/core/src/private/npy_config.h
+@@ -75,7 +75,7 @@
+ 
+ #if defined(HAVE_FEATURES_H)
+ #include <features.h>
+-#define TRIG_OK __GLIBC_PREREQ(2, 16)
++#define TRIG_OK __GLIBC_PREREQ(2, 18)
+ #else
+ #define TRIG_OK 0
+ #endif
 @@ -93,6 +93,12 @@
  #undef HAVE_CATANH
  #undef HAVE_CATANHF


### PR DESCRIPTION
This updates the patch that was originally gotten as a backport of this PR ( https://github.com/numpy/numpy/pull/6975 ) present in NumPy 1.11.0 to reflect the one that was accepted in PR ( https://github.com/numpy/numpy/pull/7657 ) in `maintenance/1.10.x` branch. If there is a 1.10.5 release, we can drop this patch.