### PR TITLE
Update to 1.11.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/README.md
+++ b/README.md
@@ -7,9 +7,21 @@ Package license: BSD 3-Clause
 
 Feedstock license: BSD 3-Clause
 
-Summary: array processing for numbers, strings, records, and objects.
+Summary: Array processing for numbers, strings, records, and objects.
 
 
+
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/numpy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/numpy-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/numpy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/numpy-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/version.svg)](https://anaconda.org/conda-forge/numpy)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/downloads.svg)](https://anaconda.org/conda-forge/numpy)
 
 Installing numpy
 ================
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `numpy` available on your platform
 ```
 conda search numpy --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/numpy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/numpy-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/numpy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/numpy-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/version.svg)](https://anaconda.org/conda-forge/numpy)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/downloads.svg)](https://anaconda.org/conda-forge/numpy)
 
 
 Updating numpy-feedstock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.11.2" %}
+{% set version = "1.11.3" %}
 
 {% set variant = "openblas" %}
 
@@ -9,10 +9,10 @@ package:
 source:
   fn: numpy-{{ version }}.tar.gz
   url: https://github.com/numpy/numpy/archive/v{{ version }}.tar.gz
-  sha256: fa2de4dc19e8ce4342a66c044d5ac90a805f8dd842435e638039250427a874a2
+  sha256: 956afdeb9b5600e873326e410e9379684dac8f8f47ea569151a417984e7799cf
 
 build:
-  number: 202
+  number: 200
   # We lack openblas on Windows, and therefore can't build numpy there either currently.
   skip: true  # [win]
   features:
@@ -44,7 +44,7 @@ about:
   home: http://numpy.scipy.org/
   license: BSD 3-Clause
   license_file: LICENSE.txt
-  summary: array processing for numbers, strings, records, and objects.
+  summary: 'Array processing for numbers, strings, records, and objects.'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
NumPy 1.11.3 Release Notes
==========================

Numpy 1.11.3 fixes a bug that leads to file corruption when very large files
opened in append mode are used in ``ndarray.tofile``. It supports Python
versions 2.6 - 2.7 and 3.2 - 3.5. Wheels for Linux, Windows, and OS X can be
found on PyPI.