### PR TITLE
MNT: Re-rendered with conda-smithy 1.7.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "CqXVmnvKLZpP0OTLO+3DlYRCcLrWlmTDnDMwrTZlYFPRuARDgM1b9j57c1gRlFM1I5MoX1/V4qZaV3UMDF6mTV9ojz8I0oRO010cUiQa97JHA3jdx+0TEgBYYK5gTYkHSo2kczEZlY0Fkb6cr16cs477v6FsE/gpW0AxoDIe+xmn4i67qrCgrj46aeCnIuM2lw865dWqqXdwF0gDbI0xgEHQo0h7uEuaCT88ZUWpVADdnEmLU3iyt8Jcy5zydue8ZEFuzbBJGGLu16umqJTWK4AA55xS96FuQa0yEj3HJYRjWd/iwFlXEdqNHUdGweOq9EMoDhrP7rDfA5zXalqM30kPXokC+QYFzqC7tr8Aw2nMaG3lxSn4ztW2h+z10mcIluzXJ+3ZwJuoy1+ELF8vvFBiJ16ApjA+TOUigZs/K1ido3BXWKJuX6JrYCrne7rpgVW1jtj9zgt9k2kVOg2RUOq9aU4ZuIfktOQcm8dluwXQcbj3l/057BpcYl2hQQk8FlTg1zF6NVH5G7XbEH5Lm4t2lcPWJusJdl1Nrfwr7qeHPqlkItW1xDNalZ+rmb8iCRo+ykS2nf+KKVvoWU/ei40oCKJ0Bly2/NA51eIMWTT5AJq+JvZGWRyMLXhP7bQCf3AJhFF5LRZTg2YI2ewh8WeQwgveZmlMV5vcvlTPBvI="

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: array processing for numbers, strings, records, and objects.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/numpy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/numpy-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/numpy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/numpy-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/version.svg)](https://anaconda.org/conda-forge/numpy)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/downloads.svg)](https://anaconda.org/conda-forge/numpy)
+
 Installing numpy
 ================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `numpy` available on your platform
 ```
 conda search numpy --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/numpy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/numpy-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/numpy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/numpy-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/version.svg)](https://anaconda.org/conda-forge/numpy)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/numpy/badges/downloads.svg)](https://anaconda.org/conda-forge/numpy)
 
 
 Updating numpy-feedstock

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
+# Embarking on 4 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -56,6 +56,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1


### PR DESCRIPTION
Re-render with `conda-smithy` version `1.7.0` to update the feedstock and provide Python 3.6 support.