### PR TITLE
Update to 1.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.12.1" %}
+{% set version = "1.13.0" %}
 
 {% set variant = "openblas" %}
 
@@ -9,7 +9,7 @@ package:
 source:
   fn: numpy-{{ version }}.tar.gz
   url: https://github.com/numpy/numpy/archive/v{{ version }}.tar.gz
-  sha256: 71253c0db5df2d0a925090b0804aa1070e9c336d891217bda5701f455d8141f7
+  sha256: dbbaaf3e86d0d138d42c61b1243d580bd6351088f0bcf2e44a7374c4559a1845
 
 build:
   number: 200


### PR DESCRIPTION
```
On behalf of the NumPy team, I am pleased to announce the NumPy 1.13.0 release. This release supports Python 2.7 and 3.4-3.6 and contains many new features. It is one of the most ambitious releases in the last several years. Some of the highlights and new functions are

Highlights
- Operations like ``a + b + c`` will reuse temporaries on some platforms, resulting in less memory use and faster execution.
- Inplace operations check if inputs overlap outputs and create temporaries to avoid problems.
- New __array_ufunc__ attribute provides improved ability for classes to override default ufunc behavior.
- New np.block function for creating blocked arrays.

New functions
- New ``np.positive`` ufunc.
- New ``np.divmod`` ufunc provides more efficient divmod.
- New ``np.isnat`` ufunc tests for NaT special values.
- New ``np.heaviside`` ufunc computes the Heaviside function.
- New ``np.isin`` function, improves on ``in1d``.
- New ``np.block`` function for creating blocked arrays.
- New ``PyArray_MapIterArrayCopyIfOverlap`` added to NumPy C-API.
```