### PR TITLE
update to 1.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.13.0" %}
+{% set version = "1.13.1" %}
 
 {% set variant = "openblas" %}
 
@@ -9,11 +9,7 @@ package:
 source:
   fn: numpy-{{ version }}.tar.gz
   url: https://github.com/numpy/numpy/archive/v{{ version }}.tar.gz
-  sha256: dbbaaf3e86d0d138d42c61b1243d580bd6351088f0bcf2e44a7374c4559a1845
-  patches:
-    # This patch fixes broken compilation of fortran extensions on windows
-    # see https://github.com/numpy/numpy/pull/9280
-    - mingw_py27.patch
+  sha256: cf8652b96582b282a5bb710aa4fe2300dca63bdd678a3cd7820314cb6c97ca89
 
 build:
   number: 200


### PR DESCRIPTION
Dropping the patch b/c it was merged upstream.

See https://github.com/numpy/numpy/releases/tag/v1.13.1