### PR TITLE
Build with OpenBLAS 0.2.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4c6b4eef790528bebb7ec9590d74cc193868940fe68e4109a91c196df72d8094
 
 build:
-  number: 200
+  number: 201
   # We lack openblas on Windows, and therefore can't build numpy there either currently.
   skip: true  # [win]
   features:
@@ -23,11 +23,11 @@ requirements:
     - python
     - setuptools
     - blas 1.1 {{ variant }}
-    - openblas 0.2.19|0.2.19.*
+    - openblas 0.2.20|0.2.20.*
   run:
     - python
     - blas 1.1 {{ variant }}
-    - openblas 0.2.19|0.2.19.*
+    - openblas 0.2.20|0.2.20.*
 
 test:
   requires:


### PR DESCRIPTION
cc @isuruf @ocefpaf 

See: https://github.com/conda-forge/scipy-feedstock/pull/75 https://github.com/conda-forge/openblas-feedstock/pull/38

Resolves a dependency conflict with the version of SciPy 1.0.0 on conda-forge.
