### PR TITLE
Fix numpy distutils ldflags overriding behaviour

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.14.5" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 {% set variant = "openblas" %}
 {% set build_number = build_number + 200 %}
@@ -11,6 +11,8 @@ package:
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
   sha256: 1b4a02758fb68a65ea986d808867f1d6383219c234aef553a8741818e795b529
+  patches:
+    - numpy_distutils_ldflags.diff
 
 build:
   number: {{ build_number }}

--- a/recipe/numpy_distutils_ldflags.diff
+++ b/recipe/numpy_distutils_ldflags.diff
@@ -1,0 +1,19 @@
+diff --git a/numpy/distutils/environment.py b/numpy/distutils/environment.py
+index 3798e16..25569d4 100644
+--- a/numpy/distutils/environment.py
++++ b/numpy/distutils/environment.py
+@@ -52,7 +52,13 @@ class EnvironmentConfig(object):
+         hook, envvar, confvar, convert = conf_desc
+         var = self._hook_handler(name, hook)
+         if envvar is not None:
+-            var = os.environ.get(envvar, var)
++            if os.environ.get('CONDA_BUILD') and envvar in ['LDFLAGS', 'LDSHARED']:
++                try:
++                    var = ' '.join(var + [os.environ.get(envvar, var)])
++                except TypeError:
++                    var = ' '.join([var] + [os.environ.get(envvar, var)])
++            else:
++                var = os.environ.get(envvar, var)
+         if confvar is not None and self._conf:
+             var = self._conf.get(confvar, (None, var))[1]
+         if convert is not None:

--- a/recipe/numpy_distutils_ldflags.diff
+++ b/recipe/numpy_distutils_ldflags.diff
@@ -1,19 +1,122 @@
 diff --git a/numpy/distutils/environment.py b/numpy/distutils/environment.py
-index 3798e16..25569d4 100644
+index 3798e16..01b5f9b 100644
 --- a/numpy/distutils/environment.py
 +++ b/numpy/distutils/environment.py
-@@ -52,7 +52,13 @@ class EnvironmentConfig(object):
-         hook, envvar, confvar, convert = conf_desc
+@@ -14,7 +14,7 @@ class EnvironmentConfig(object):
+ 
+     def dump_variable(self, name):
+         conf_desc = self._conf_keys[name]
+-        hook, envvar, confvar, convert = conf_desc
++        hook, envvar, confvar, convert, append = conf_desc
+         if not convert:
+             convert = lambda x : x
+         print('%s.%s:' % (self._distutils_section, name))
+@@ -49,10 +49,20 @@ class EnvironmentConfig(object):
+         return var
+ 
+     def _get_var(self, name, conf_desc):
+-        hook, envvar, confvar, convert = conf_desc
++        hook, envvar, confvar, convert, append = conf_desc
          var = self._hook_handler(name, hook)
          if envvar is not None:
 -            var = os.environ.get(envvar, var)
-+            if os.environ.get('CONDA_BUILD') and envvar in ['LDFLAGS', 'LDSHARED']:
-+                try:
-+                    var = ' '.join(var + [os.environ.get(envvar, var)])
-+                except TypeError:
-+                    var = ' '.join([var] + [os.environ.get(envvar, var)])
-+            else:
-+                var = os.environ.get(envvar, var)
++            envvar_contents = os.environ.get(envvar)
++            if envvar_contents is not None:
++                if append and os.environ.get('NPY_DISTUTILS_APPEND_FLAGS', '1') == '1':
++                    if var is None:
++                        var = ''
++                    try:
++                        var = ' '.join(var + [envvar_contents])
++                    except TypeError:
++                        var = ' '.join([var] + [envvar_contents])
++                else:
++                    var = envvar_contents
          if confvar is not None and self._conf:
              var = self._conf.get(confvar, (None, var))[1]
          if convert is not None:
+diff --git a/numpy/distutils/fcompiler/__init__.py b/numpy/distutils/fcompiler/__init__.py
+index c926e73..1a3559f 100644
+--- a/numpy/distutils/fcompiler/__init__.py
++++ b/numpy/distutils/fcompiler/__init__.py
+@@ -91,7 +91,7 @@ class FCompiler(CCompiler):
+ 
+     # These are the environment variables and distutils keys used.
+     # Each configuration description is
+-    # (<hook name>, <environment variable>, <key in distutils.cfg>, <convert>)
++    # (<hook name>, <environment variable>, <key in distutils.cfg>, <convert>, <append>)
+     # The hook names are handled by the self._environment_hook method.
+     #  - names starting with 'self.' call methods in this class
+     #  - names starting with 'exe.' return the key in the executables dict
+@@ -101,43 +101,43 @@ class FCompiler(CCompiler):
+ 
+     distutils_vars = EnvironmentConfig(
+         distutils_section='config_fc',
+-        noopt = (None, None, 'noopt', str2bool),
+-        noarch = (None, None, 'noarch', str2bool),
+-        debug = (None, None, 'debug', str2bool),
+-        verbose = (None, None, 'verbose', str2bool),
++        noopt = (None, None, 'noopt', str2bool, False),
++        noarch = (None, None, 'noarch', str2bool, False),
++        debug = (None, None, 'debug', str2bool, False),
++        verbose = (None, None, 'verbose', str2bool, False),
+     )
+ 
+     command_vars = EnvironmentConfig(
+         distutils_section='config_fc',
+-        compiler_f77 = ('exe.compiler_f77', 'F77', 'f77exec', None),
+-        compiler_f90 = ('exe.compiler_f90', 'F90', 'f90exec', None),
+-        compiler_fix = ('exe.compiler_fix', 'F90', 'f90exec', None),
+-        version_cmd = ('exe.version_cmd', None, None, None),
+-        linker_so = ('exe.linker_so', 'LDSHARED', 'ldshared', None),
+-        linker_exe = ('exe.linker_exe', 'LD', 'ld', None),
+-        archiver = (None, 'AR', 'ar', None),
+-        ranlib = (None, 'RANLIB', 'ranlib', None),
++        compiler_f77 = ('exe.compiler_f77', 'F77', 'f77exec', None, False),
++        compiler_f90 = ('exe.compiler_f90', 'F90', 'f90exec', None, False),
++        compiler_fix = ('exe.compiler_fix', 'F90', 'f90exec', None, False),
++        version_cmd = ('exe.version_cmd', None, None, None, False),
++        linker_so = ('exe.linker_so', 'LDSHARED', 'ldshared', None, True),
++        linker_exe = ('exe.linker_exe', 'LD', 'ld', None, False),
++        archiver = (None, 'AR', 'ar', None, False),
++        ranlib = (None, 'RANLIB', 'ranlib', None, False),
+     )
+ 
+     flag_vars = EnvironmentConfig(
+         distutils_section='config_fc',
+-        f77 = ('flags.f77', 'F77FLAGS', 'f77flags', flaglist),
+-        f90 = ('flags.f90', 'F90FLAGS', 'f90flags', flaglist),
+-        free = ('flags.free', 'FREEFLAGS', 'freeflags', flaglist),
+-        fix = ('flags.fix', None, None, flaglist),
+-        opt = ('flags.opt', 'FOPT', 'opt', flaglist),
+-        opt_f77 = ('flags.opt_f77', None, None, flaglist),
+-        opt_f90 = ('flags.opt_f90', None, None, flaglist),
+-        arch = ('flags.arch', 'FARCH', 'arch', flaglist),
+-        arch_f77 = ('flags.arch_f77', None, None, flaglist),
+-        arch_f90 = ('flags.arch_f90', None, None, flaglist),
+-        debug = ('flags.debug', 'FDEBUG', 'fdebug', flaglist),
+-        debug_f77 = ('flags.debug_f77', None, None, flaglist),
+-        debug_f90 = ('flags.debug_f90', None, None, flaglist),
+-        flags = ('self.get_flags', 'FFLAGS', 'fflags', flaglist),
+-        linker_so = ('flags.linker_so', 'LDFLAGS', 'ldflags', flaglist),
+-        linker_exe = ('flags.linker_exe', 'LDFLAGS', 'ldflags', flaglist),
+-        ar = ('flags.ar', 'ARFLAGS', 'arflags', flaglist),
++        f77 = ('flags.f77', 'F77FLAGS', 'f77flags', flaglist, True),
++        f90 = ('flags.f90', 'F90FLAGS', 'f90flags', flaglist, True),
++        free = ('flags.free', 'FREEFLAGS', 'freeflags', flaglist, True),
++        fix = ('flags.fix', None, None, flaglist, False),
++        opt = ('flags.opt', 'FOPT', 'opt', flaglist, True),
++        opt_f77 = ('flags.opt_f77', None, None, flaglist, False),
++        opt_f90 = ('flags.opt_f90', None, None, flaglist, False),
++        arch = ('flags.arch', 'FARCH', 'arch', flaglist, False),
++        arch_f77 = ('flags.arch_f77', None, None, flaglist, False),
++        arch_f90 = ('flags.arch_f90', None, None, flaglist, False),
++        debug = ('flags.debug', 'FDEBUG', 'fdebug', flaglist, True),
++        debug_f77 = ('flags.debug_f77', None, None, flaglist, False),
++        debug_f90 = ('flags.debug_f90', None, None, flaglist, False),
++        flags = ('self.get_flags', 'FFLAGS', 'fflags', flaglist, True),
++        linker_so = ('flags.linker_so', 'LDFLAGS', 'ldflags', flaglist, True),
++        linker_exe = ('flags.linker_exe', 'LDFLAGS', 'ldflags', flaglist, True),
++        ar = ('flags.ar', 'ARFLAGS', 'arflags', flaglist, True),
+     )
+ 
+     language_map = {'.f': 'f77',


### PR DESCRIPTION
I'll backport this patch to other releases if this is accepted. (The file hasn't been touched in 5 years, which makes it easy to backport.)

xref: https://github.com/numpy/numpy/issues/7427
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
