### PR TITLE
Readd feature

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,10 @@ source:
     - 11525.patch
 
 build:
-  number: 204
+  number: 205
   skip: True  # [win]
+  features:
+    - blas_{{ variant }}
 
 requirements:
   build:


### PR DESCRIPTION
Seems i accidentally removed the blas feature.  Not having it causes older build numbers to be favored by the solver.