### PR TITLE
Fix scikit-learn

### DIFF
--- a/.ci_support/linux_c_compilergcccxx_compilergxxfortran_compilergfortranpython2.7.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxfortran_compilergfortranpython2.7.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 numpy:

--- a/.ci_support/linux_c_compilergcccxx_compilergxxfortran_compilergfortranpython3.6.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxfortran_compilergfortranpython3.6.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 numpy:

--- a/.ci_support/linux_c_compilergcccxx_compilergxxfortran_compilergfortranpython3.7.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxfortran_compilergfortranpython3.7.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 numpy:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,11 @@ source:
     - correct-c-compiler-customization-in-system_info.py.patch
     # port https://github.com/numpy/numpy/commit/e552922fe6c8854541337a10970ff1b62caffc70
     - fix-arrayterator-back_port_e552922.patch  # [py>=35]
+    # fix needed to compile downstream packages on Linux with newer openblas
+    - treat-openblas-as-c.patch  # [linux]
 
 build:
-  number: 1006
+  number: 1007
   # We lack openblas on Windows, and therefore can't build numpy there either currently.
   skip: True  # [win]
   features:

--- a/recipe/treat-openblas-as-c.patch
+++ b/recipe/treat-openblas-as-c.patch
@@ -1,0 +1,13 @@
+diff --git a/numpy/distutils/system_info.py b/numpy/distutils/system_info.py
+index a050430..b929762 100644
+--- a/numpy/distutils/system_info.py
++++ b/numpy/distutils/system_info.py
+@@ -1659,7 +1659,7 @@ class openblas_info(blas_info):
+         if not self.check_embedded_lapack(info):
+             return None
+ 
+-        info['language'] = 'f77'  # XXX: is it generally true?
++        info['language'] = 'c'  # XXX: is it generally true?
+         self.set_info(**info)
+ 
+ 


### PR DESCRIPTION
Numpy 1.9 hardcodes that openblas should be treated as a FORTRAN library, but that seems to break with version 0.3 — not in Numpy itself, but when building scikit-learn, as per [its #76](https://github.com/conda-forge/scikit-learn-feedstock/pull/76). This patch fixes sklearn in local testing.