### PR TITLE
[WIP] remove blas_openblas feature

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,8 @@ source:
     - numpy_distutils_ldflags.diff
 
 build:
-  number: 1000
+  number: 1001
   skip: true  # [win32 or (win and py27)]
-  features:
-    - blas_{{ variant }}
 
 requirements:
   build:


### PR DESCRIPTION
blas mpkg is being hotfixed by [this repo](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock) to remove track_features, so packages with this feature built after the hotfixes were rendered (around the end of August) are not getting installed.

To verify:

    conda create -override-channels -c conda-forge --dry-run -p /tmp/x numpy

gets:

    numpy:           1.15.1-py36_blas_openblashd3ea46f_0 conda-forge

which was uploaded around that time.

And

    conda create -=override-channels -c conda-forge --dry-run -p /tmp/x numpy=1.15.4

gets numpy from defaults because there is no valid numpy 1.15.4 on conda-forge.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->