### PR TITLE
Rerender and add as a maintainer

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,23 +11,23 @@ jobs:
       linux_64_numpy1.16python3.6.____cpython:
         CONFIG: linux_64_numpy1.16python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.16python3.7.____cpython:
         CONFIG: linux_64_numpy1.16python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.16python3.8.____cpython:
         CONFIG: linux_64_numpy1.16python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.18python3.6.____73_pypy:
         CONFIG: linux_64_numpy1.18python3.6.____73_pypy
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.19python3.9.____cpython:
         CONFIG: linux_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
 cdt_name:
 - cos7
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
 cdt_name:
 - cos7
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
 cdt_name:
 - cos7
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.6.____73_pypy.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
 cdt_name:
 - cos7
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
 cdt_name:
 - cos7
 channel_sources:
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge,https://conda-web.anaconda.org/conda-forge
+- conda-forge/label/rust_dev,conda-forge
 channel_targets:
 - conda-forge main
 libblas:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge,https://conda-web.anaconda.org/conda-forge
+- conda-forge/label/rust_dev,conda-forge
 channel_targets:
 - conda-forge main
 libblas:

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_numpy1.16python3.6.____cpython
     UPLOAD_PACKAGES: True
@@ -39,7 +39,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_numpy1.16python3.7.____cpython
     UPLOAD_PACKAGES: True
@@ -70,7 +70,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_numpy1.16python3.8.____cpython
     UPLOAD_PACKAGES: True
@@ -101,7 +101,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_numpy1.18python3.6.____73_pypy
     UPLOAD_PACKAGES: True
@@ -132,7 +132,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_numpy1.19python3.9.____cpython
     UPLOAD_PACKAGES: True

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @isuruf @jakirkham @msarahan @ocefpaf @pelson @rgommers
+* @isuruf @jakirkham @msarahan @ocefpaf @pelson @rgommers @xhochy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,23 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_numpy1.16python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_numpy1.16python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_numpy1.16python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_numpy1.16python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_numpy1.16python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_numpy1.16python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_numpy1.18python3.6.____73_pypy UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_numpy1.18python3.6.____73_pypy UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_numpy1.19python3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_numpy1.19python3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/README.md
+++ b/README.md
@@ -332,4 +332,5 @@ Feedstock Maintainers
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@pelson](https://github.com/pelson/)
 * [@rgommers](https://github.com/rgommers/)
+* [@xhochy](https://github.com/xhochy/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,8 @@ build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 test_on_native_only: true
+bot:
+  abi_migration_branches:
+    - "numpy116"
+    - "numpy117"
+    - "numpy118"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,8 +2,3 @@ build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 test_on_native_only: true
-bot:
-  abi_migration_branches:
-    - "numpy116"
-    - "numpy117"
-    - "numpy118"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - cblas.diff
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py27]
   entry_points:
     - f2py = numpy.f2py.f2py2e:main  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,13 +57,15 @@ requirements:
 test:
   requires:
     - pytest
+    - pytest-xdist  # [aarch64]
     - hypothesis
     - setuptools
   commands:
     - f2py -h
     - export OPENBLAS_NUM_THREADS=1  # [unix]
     - set OPENBLAS_NUM_THREADS=1  # [win]
-    - pytest --verbose --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
+    - pytest --verbose --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0         # [not aarch64]
+    - pytest -nauto --verbose --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0  # [aarch64]
   imports:
     - numpy
     - numpy.linalg.lapack_lite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,3 +84,4 @@ extra:
     - rgommers
     - ocefpaf
     - isuruf
+    - xhochy


### PR DESCRIPTION
The bot fleet can now run on branches if you request it from them. Enable this for `numpy` as old releases are used for building packages and should be kept uptodate with conda-forge's pinning.

Please review this and approve. I can merge myself later. I would do the following before merging so that we have new builds with the latest pinnings before we do new builds with the current migrations.

- [ ] Rerender on the `numpy116` branch
- [ ] Rerender on the `numpy117` branch
- [ ] Create a `numpy118` branch
- [ ] Rerender on the `numpy118` branch

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
