### PR TITLE
Pin to `setuptools<60.0.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
   #   folder: numpy/core/src/umath/svml
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   entry_points:
     - f2py = numpy.f2py.f2py2e:main  # [win]
@@ -30,6 +30,7 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cython                                 # [build_platform != target_platform]
+    - setuptools <60.0.0
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -53,7 +54,7 @@ test:
   requires:
     - pytest
     - hypothesis
-    - setuptools
+    - setuptools <60.0.0
     # some linux tests need a compiler
     - {{ compiler('c') }}  # [linux]
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
   run_constrained:
     # enforce eviction of package from anaconda defaults
     - numpy-base <0a0
+    - setuptools <60.0.0
 
 {% set tests_to_skip = "_not_a_real_test" %}
 # there are some tests that cannot really work in emulation, see e.g. numpy/numpy#20445
@@ -54,7 +55,7 @@ test:
   requires:
     - pytest
     - hypothesis
-    - setuptools <60.0.0
+    - setuptools
     # some linux tests need a compiler
     - {{ compiler('c') }}  # [linux]
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ requirements:
   run_constrained:
     # enforce eviction of package from anaconda defaults
     - numpy-base <0a0
-    - setuptools <60.0.0
 
 {% set tests_to_skip = "_not_a_real_test" %}
 # there are some tests that cannot really work in emulation, see e.g. numpy/numpy#20445
@@ -55,7 +54,7 @@ test:
   requires:
     - pytest
     - hypothesis
-    - setuptools
+    - setuptools <60.0.0
     # some linux tests need a compiler
     - {{ compiler('c') }}  # [linux]
   commands:


### PR DESCRIPTION
NumPy does not support `setuptools >=60.0`, because that is the release that re-enabled the vendored `distutils` copy in
`setuptools`, and it has backwards compatibility issues with `numpy.distutils`. There is currently no plan to resolve those;
NumPy itself will keep this pin, and other projects are advised to migrate away from `numpy.distutils`.
