### PR TITLE
Add run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,12 @@ source:
   #   folder: numpy/core/src/umath/svml
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   entry_points:
     - f2py = numpy.f2py.f2py2e:main  # [win]
+  run_exports:
+    - {{ pin_subpackage("numpy") }}
 
 requirements:
   build:


### PR DESCRIPTION
Since we have removed most python packages in `host` now, we can be reasonably
sure that `numpy` in `host` means there should be a constraint on the numpy
version.