### PR TITLE
Run full test suite

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,6 +20,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    SET_PAGEFILE: 'True'
 
   steps:
     - script: |

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,7 @@
+azure:
+  settings_win:
+    variables:
+      SET_PAGEFILE: "True"
 build_platform: {osx_arm64: osx_64, linux_aarch64: linux_64, linux_ppc64le: linux_64}
 conda_forge_output_validation: true
 provider: {win: azure}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,8 @@ test:
     # failures that occured depending on presence/absence of e.g. AVX512);
     # for signature of numpy.test see the following (note default: label='fast'),
     # https://github.com/numpy/numpy/blob/maintenance/1.22.x/numpy/_pytesttester.py#L81-L82
-    {% set param = "verbose=1, label='full', tests=None" %}
+    {% set label = "'fast'" if aarch64 else "'full'" %}
+    {% set param = "verbose=1, label=" + label + ", tests=None" %}
     {% set extra = "extra_argv=['-k', 'not (" + tests_to_skip + ")', '-nauto', '--timeout=600', '--durations=50']" %}
     - python -c "import numpy, sys; sys.exit(not numpy.test({{ param }}, {{ extra }}))"  # [not ppc64le]
     # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,8 @@ requirements:
 test:
   requires:
     - pytest
+    - pytest-timeout
+    - pytest-xdist
     - hypothesis
     - setuptools <60.0.0
     # some linux tests need a compiler
@@ -62,8 +64,12 @@ test:
   commands:
     - f2py -h
     # numpy.test will show SIMD features of agent (in the past, there have been
-    # failures that occured depending on presence/absence of e.g. AVX512)
-    - python -c "import numpy, sys; sys.exit(not numpy.test(verbose=3, durations=50, extra_argv=['-k', 'not ({{ tests_to_skip }})']))"  # [not ppc64le]
+    # failures that occured depending on presence/absence of e.g. AVX512);
+    # for signature of numpy.test see the following (note default: label='fast'),
+    # https://github.com/numpy/numpy/blob/maintenance/1.22.x/numpy/_pytesttester.py#L81-L82
+    {% set param = "verbose=1, label='full', tests=None" %}
+    {% set extra = "extra_argv=['-k', 'not (" + tests_to_skip + ")', '-nauto', '--timeout=600', '--durations=50']" %}
+    - python -c "import numpy, sys; sys.exit(not numpy.test({{ param }}, {{ extra }}))"  # [not ppc64le]
     # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
     # CI to fail, even though the tests should run through on native hardware
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,10 @@ requirements:
 
 {% set tests_to_skip = "_not_a_real_test" %}
 # there are some tests that cannot really work in emulation, see e.g. numpy/numpy#20445
-{% set tests_to_skip = tests_to_skip + " or Test_ARM_Features" %}  # [build_platform != target_platform]
+{% set tests_to_skip = tests_to_skip + " or Test_ARM_Features" %}               # [build_platform != target_platform]
+# flaky refcount-based test; already skipped upstream for win+py39
+{% set tests_to_skip = tests_to_skip + " or test_partial_iteration_cleanup" %}  # [osx]
+
 
 test:
   requires:


### PR DESCRIPTION
Noticed yesterday that this wasn't yet running all tests, but just those with `label='fast'`.