### PR TITLE
numpy 1.21.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.21.5" %}
+{% set version = "1.21.6" %}
 
 package:
   name: numpy
@@ -6,13 +6,13 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 1a7ee0ffb35dc7489aebe5185a483f4c43b0d2cf784c3c9940f975a7dde56506
+  sha256: d4efc6491a1cdc00f9eca9bf2c1aa13671776f6941c7321ddf75b45c862f0c2c
   patches:
     # carry numpy/numpy#19450 to help with flaky hypothesis errors
     - patches/0001-TST-Simplify-property-test.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<37]
   entry_points:
     - f2py = numpy.f2py.f2py2e:main  # [win]


### PR DESCRIPTION
Against expectations, a new [release](https://github.com/numpy/numpy/releases/tag/v1.21.6) for 1.21.x. :)