### PR TITLE
Add runtime _numpy_rc dependency for rc builds and publish to main

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -69,6 +69,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -36,6 +36,7 @@ jobs:
         CONFIG: osx_arm64_numpy1.26python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -44,6 +48,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -44,6 +48,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -44,6 +48,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -44,6 +48,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -44,6 +48,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -2,10 +2,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -40,6 +44,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy
   - python_impl

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -4,8 +4,12 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
-- conda-forge
+- conda-forge/label/numpy_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -68,7 +68,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 
 
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -55,7 +55,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-win.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_sources:
+  - conda-forge/label/numpy_rc,conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,10 +103,8 @@ test:
     - python -c "import numpy, sys; sys.exit(not numpy.test({{ param }}, {{ extra }}))"
   imports:
     - numpy
-    # reference for public API is effectively
+    # reference for public API is effectively PUBLIC_MODULES under
     # https://github.com/numpy/numpy/blame/main/numpy/tests/test_public_api.py
-    - numpy.array_api
-    - numpy.array_api.linalg
     - numpy.ctypeslib
     - numpy.distutils           # [py<312]
     - numpy.dtypes
@@ -114,18 +112,30 @@ test:
     - numpy.f2py
     - numpy.fft
     - numpy.lib
+    - numpy.lib.format
     - numpy.lib.mixins
     - numpy.lib.recfunctions
     - numpy.lib.scimath
+    - numpy.lib.stride_tricks
+    - numpy.lib.npyio
+    - numpy.lib.introspect
+    - numpy.lib.array_utils
     - numpy.linalg
     - numpy.ma
     - numpy.ma.extras
     - numpy.ma.mrecords
-    - numpy.matlib
     - numpy.polynomial
+    - numpy.polynomial.chebyshev
+    - numpy.polynomial.hermite
+    - numpy.polynomial.hermite_e
+    - numpy.polynomial.laguerre
+    - numpy.polynomial.legendre
+    - numpy.polynomial.polynomial
     - numpy.random
     - numpy.testing
+    - numpy.testing.overrides
     - numpy.typing
+    - numpy.typing.mypy_plugin
     - numpy.version
     # some private modules that were once upon a time
     # determined to be useful packaging checks

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - ninja                                  # [build_platform != target_platform]
     - pkg-config                             # [build_platform != target_platform]
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,6 @@ requirements:
 test:
   requires:
     - pytest
-    - pytest <8            # [python_impl == "pypy"]
     - pytest-timeout
     - pytest-xdist
     # (mostly) optional test requirements (except wheel, python-cov, mypy), see

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ build:
   number: 0
   skip: true  # [py<39]
   entry_points:
-    - f2py = numpy.f2py.f2py2e:main  # [win]
+    - f2py = numpy.f2py.f2py2e:main             # [win]
+    - numpy-config = numpy._configtool:main     # [win]
   run_exports:
     - {{ pin_subpackage("numpy") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0b1" %}
+{% set version = "2.0.0rc1" %}
 
 package:
   name: numpy
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: e0bb33a37d0d0b9a19cd41a093877f830e06bd4d989341b9792896cf08e629f7
+    sha256: f0e169ec6cbc1b8e5f6a235845a80961f76f88352082213a1728a0967a761ad2
   # the sources by upstream themselves (as opposed to automated by github) contain the
   # svml submodule (which isn't in github tarball due to dear-github/dear-github#214);
   # keep this for reference & debugging when necessary; for exact commit, see:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,8 @@
 {% set version = "2.0.0rc1" %}
+# numpy will by default use the ABI feature level for the first numpy version
+# that added support for the oldest currently-supported CPython version; see
+# https://github.com/numpy/numpy/blob/v2.0.0rc1/numpy/_core/include/numpy/numpyconfig.h#L124
+{% set default_abi_level = "1.19" %}
 
 package:
   name: numpy
@@ -28,7 +32,7 @@ build:
     - f2py = numpy.f2py.f2py2e:main             # [win]
     - numpy-config = numpy._configtool:main     # [win]
   run_exports:
-    - {{ pin_subpackage("numpy") }}
+    - numpy >={{ default_abi_level }},<3
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "2.0.0rc1" %}
+{% set version = "2.0.0" %}
+{% set dev = "rc1" %}
 # numpy will by default use the ABI feature level for the first numpy version
 # that added support for the oldest currently-supported CPython version; see
 # https://github.com/numpy/numpy/blob/v2.0.0rc1/numpy/_core/include/numpy/numpyconfig.h#L124
@@ -6,13 +7,13 @@
 
 package:
   name: numpy
-  version: {{ version }}
+  version: {{ version }}{{ dev }}
 
 # use 'python_impl' in meta.yaml so it gets picked up by rendering
 # [python_impl == "pypy"]
 
 source:
-  - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
+  - url: https://github.com/numpy/numpy/releases/download/v{{ version }}{{ dev }}/numpy-{{ version }}{{ dev }}.tar.gz
     sha256: f0e169ec6cbc1b8e5f6a235845a80961f76f88352082213a1728a0967a761ad2
   # the sources by upstream themselves (as opposed to automated by github) contain the
   # svml submodule (which isn't in github tarball due to dear-github/dear-github#214);
@@ -59,6 +60,9 @@ requirements:
     - liblapack
   run:
     - python
+{% if dev != '' %}
+    - _numpy_rc
+{% endif %}
   run_constrained:
     # enforce eviction of package from anaconda defaults
     - numpy-base <0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ requirements:
 # test_new_policy reruns part of test suite; including a CPU feature test that fails in emulation
 {% set tests_to_skip = tests_to_skip + " or test_new_policy" %}                     # [build_platform != target_platform]
 # emulation problems (apparently) on aarch
-{% set tests_to_skip = tests_to_skip + " or test_basic_property[float32" %}         # [aarch64]
+{% set tests_to_skip = tests_to_skip + " or (test_basic_property and float32)" %}   # [aarch64]
 # problems with windows + pypy + meson
 {% set tests_to_skip = tests_to_skip + " or test_cython or test_mem_policy" %}      # [win and python_impl == "pypy"]
 {% set tests_to_skip = tests_to_skip + " or test_multi_fortran_libs_link" %}        # [win and python_impl == "pypy"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.26.4" %}
+{% set version = "2.0.0b1" %}
 
 package:
   name: numpy
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
+    sha256: e0bb33a37d0d0b9a19cd41a093877f830e06bd4d989341b9792896cf08e629f7
   # the sources by upstream themselves (as opposed to automated by github) contain the
   # svml submodule (which isn't in github tarball due to dear-github/dear-github#214);
   # keep this for reference & debugging when necessary; for exact commit, see:


### PR DESCRIPTION
Modeled after https://github.com/conda-forge/python-feedstock/pull/648, needs https://github.com/conda-forge/staged-recipes/pull/26188; for discussion see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5790

Created by rebasing #312 onto main (with some selective commit clean-ups) and then applying https://github.com/conda-forge/numpy-feedstock/pull/314/commits/cff4ef3657057215494aa2538cf77b34eaa4db65 + a fresh rerender.