### PR TITLE
TRY: Revert to 2.2.3 just to see if it triggers the new issue seen in 2.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
-# Pixi's configuration
-.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.4" %}
+{% set version = "2.2.3" %}
 {% set dev = "" %}
 # numpy will by default use the ABI feature level for the first numpy version
 # that added support for the oldest currently-supported CPython version; see
@@ -18,7 +18,7 @@ source:
   # the submodules (not in tarball due to dear-github/dear-github#214); for the
   # list of modules see https://github.com/numpy/numpy/blob/main/.gitmodules
   - url: https://github.com/numpy/numpy/archive/refs/tags/v{{ version }}{{ dev }}.tar.gz
-    sha256: 011a9483768b14bb00c6dab1c666f6d86f95b23036eb1e4b2b65db700f98c9a3
+    sha256: f464ffd7ee536a71edb8227855bb35750847f0f307ecbb2df519d34d0daa8f10
   # https://github.com/numpy/numpy/tree/v{{ version }}/numpy/_core/src
   - folder: numpy/_core/src/highway
     git_url: https://github.com/google/highway.git
@@ -95,11 +95,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or (test_basic_property and float32)" %}   # [aarch64]
 # https://github.com/numpy/numpy/issues/27045
 {% set tests_to_skip = tests_to_skip + " or (test_regression and test_gh25784)" %}  # [osx]
-# new test failures for 2.2.4; possibly emulation-related; see
-# https://github.com/numpy/numpy/issues/28548
-{% set tests_to_skip = tests_to_skip + " or test_einsum_sums_float32" %}            # [ppc64le]
-{% set tests_to_skip = tests_to_skip + " or test_ufunc_noncontiguous[matvec]" %}    # [ppc64le]
-{% set tests_to_skip = tests_to_skip + " or test_accelerate_framework_sgemv_fix " %}  # [ppc64le]
 
 test:
   requires:


### PR DESCRIPTION
I was curious if there is a change that isn't NumPy involved here, so wanted to try and see what happens if I revert gh-349.

I.e. the PPC failure there seems likely unrelated to NumPy changes (but a real SIMD bug, although that could just be a bug in qemu or so).  But thought it may be helpful to see that.